### PR TITLE
[ci]: scrum-2882 - use code build runners

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,12 +1,12 @@
 name: PR Title Checker
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [ opened, edited, synchronize, reopened ]
 
 jobs:
   check-pr-title:
     name: Validate PR Title conventions
-    runs-on: ubuntu-latest
+    runs-on: codebuild-runner-tiny-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
       - name: Check PR Title
@@ -14,13 +14,13 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-
-            const NORMAL_PR_PATTERN = /^\[(feat|fix|chore|docs|refactor|perf|test|build|ci|revert)\]:\s+((?:rofano|scrum)-\d+)\s+-\s+.+$/;
+            
+            const NORMAL_PR_PATTERN = /^\[(feat|fix|chore|docs|refactor|perf|test|build|ci|revert)\]:\s+((?:rofano|scrum|devops)-\d+)\s+-\s+.+$/;
             const RELEASE_PR_PATTERN = /^(MEP|MEPP)\s+\d{2}-\d{2}-\d{4}\s+-\s+V\d+\.\d+\.\d+$/;
-
+            
             const isNormalTitle = NORMAL_PR_PATTERN.test(title);
             const isReleaseTitle = RELEASE_PR_PATTERN.test(title);
-
+            
             if (isNormalTitle) {
               if (title.length > 100) {
                 core.setFailed(`Le titre ne doit pas dépasser 100 caractères. Longueur actuelle : ${title.length}`);
@@ -29,13 +29,14 @@ jobs:
                 core.setFailed(`Le titre doit être entièrement en minuscules.`);
               }
             }
-
+            
             if (!isNormalTitle && !isReleaseTitle) {
               core.setFailed(`Format de titre invalide.
-
+            
               1. Pour les PR classiques: 
               - [type]: rofano-XXX - description
               - [type]: scrum-XXX - description
+              - [type]: devops-XXX - description
               Liste des types possibles : 
               - feat
               - fix
@@ -50,7 +51,7 @@ jobs:
               2. Pour les PR de release:
               - MEP DD-MM-YYYY - version_number
               - MEPP DD-MM-YYYY - version_number
-
+            
               Note: 
               - Le titre doit être en minuscules
               - Maximum 100 caractères`);

--- a/.github/workflows/sonar-analysis.yaml
+++ b/.github/workflows/sonar-analysis.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   frontend-analysis:
     name: Frontend Analysis
-    runs-on: codebuild-runner-tiny-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-runner-privileged-boosted-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sonar-analysis.yaml
+++ b/.github/workflows/sonar-analysis.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   frontend-analysis:
     name: Frontend Analysis
-    runs-on: ubuntu-latest
+    runs-on: codebuild-runner-tiny-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/start_pipeline.yaml
+++ b/.github/workflows/start_pipeline.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   deploy:
     name: Start AWS pipeline
-    runs-on: [rofim-tiny]
+    runs-on: codebuild-runner-tiny-${{ github.run_id }}-${{ github.run_attempt }}
     # Deployment environment information in GitHub also used by JIRA to update the ticket status
     environment: ${{ github.ref_name == 'develop' && 'staging' || inputs.environment }}
     # Runtime environment variable used in deployment

--- a/.github/workflows/start_pipeline.yaml
+++ b/.github/workflows/start_pipeline.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   deploy:
-    name: Start AWS pipeline
+    name: Start AWS pipeline for visio on ${{ inputs.environment || 'staging' }}}
     runs-on: codebuild-runner-tiny-${{ github.run_id }}-${{ github.run_attempt }}
     # Deployment environment information in GitHub also used by JIRA to update the ticket status
     environment: ${{ github.ref_name == 'develop' && 'staging' || inputs.environment }}

--- a/.github/workflows/start_pipeline.yaml
+++ b/.github/workflows/start_pipeline.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check AWS pipeline
         run: |
-          echo ${{ steps.deploy.outputs.pipelineExecutionId }}
+          echo ${{ steps.start-pipeline.outputs.pipelineExecutionId }}
           i=0
           max=80
           while true; do
@@ -84,7 +84,7 @@ jobs:
               echo "Waiting for too long, ... Exiting"
               exit 1
             fi
-            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-${{ inputs.environment }}-${{ inputs.app }} --pipeline-execution-id ${{ steps.deploy.outputs.pipelineExecutionId }} | jq .pipelineExecution.status -r)
+            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-$ENVIRONMENT-$APP --pipeline-execution-id ${{ steps.start-pipeline.outputs.pipelineExecutionId }} |jq .pipelineExecution.status -r)
             echo "[$i/$max] Current status is $status"
             if [[ "$status" == "Succeeded" ]]; then
               break

--- a/.github/workflows/start_pipeline.yaml
+++ b/.github/workflows/start_pipeline.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check AWS pipeline
         run: |
-          echo ${{ steps.start-pipeline.outputs.pipelineExecutionId }}
+          echo ${{ steps.deploy.outputs.pipelineExecutionId }}
           i=0
           max=80
           while true; do
@@ -84,7 +84,7 @@ jobs:
               echo "Waiting for too long, ... Exiting"
               exit 1
             fi
-            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-$ENVIRONMENT-$APP --pipeline-execution-id ${{ steps.start-pipeline.outputs.pipelineExecutionId }} |jq .pipelineExecution.status -r)
+            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-${{ inputs.environment }}-${{ inputs.app }} --pipeline-execution-id ${{ steps.deploy.outputs.pipelineExecutionId }} | jq .pipelineExecution.status -r)
             echo "[$i/$max] Current status is $status"
             if [[ "$status" == "Succeeded" ]]; then
               break

--- a/.github/workflows/start_pipeline.yaml
+++ b/.github/workflows/start_pipeline.yaml
@@ -66,15 +66,15 @@ jobs:
           aws-region: eu-west-1
 
       - name: Start AWS pipeline
-        id: deploy
+        id: start-pipeline
         run: |
           commit_id=$(git rev-parse "${{ steps.branch_tag_name.outputs.branch_or_tag }}")
-          pipelineExecutionId=$(aws codepipeline start-pipeline-execution --name rofim-${{ inputs.environment }}-${{ inputs.app }} --source-revisions actionName=Source,revisionType=COMMIT_ID,revisionValue=$commit_id | jq .pipelineExecutionId)
+          pipelineExecutionId=$(aws codepipeline start-pipeline-execution --name rofim-$ENVIRONMENT-$APP --source-revisions actionName=Source,revisionType=COMMIT_ID,revisionValue=$commit_id |jq -r .pipelineExecutionId)
           echo "pipelineExecutionId=$pipelineExecutionId" >> $GITHUB_OUTPUT
 
       - name: Check AWS pipeline
         run: |
-          echo ${{ steps.deploy.outputs.pipelineExecutionId }}
+          echo ${{ steps.start-pipeline.outputs.pipelineExecutionId }}
           i=0
           max=80
           while true; do
@@ -84,7 +84,7 @@ jobs:
               echo "Waiting for too long, ... Exiting"
               exit 1
             fi
-            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-${{ inputs.environment }}-${{ inputs.app }} --pipeline-execution-id ${{ steps.deploy.outputs.pipelineExecutionId }} | jq .pipelineExecution.status -r)
+            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-$ENVIRONMENT-$APP --pipeline-execution-id ${{ steps.start-pipeline.outputs.pipelineExecutionId }} |jq .pipelineExecution.status -r)
             echo "[$i/$max] Current status is $status"
             if [[ "$status" == "Succeeded" ]]; then
               break

--- a/.github/workflows/start_pipeline.yaml
+++ b/.github/workflows/start_pipeline.yaml
@@ -66,15 +66,15 @@ jobs:
           aws-region: eu-west-1
 
       - name: Start AWS pipeline
-        id: start-pipeline
+        id: deploy
         run: |
           commit_id=$(git rev-parse "${{ steps.branch_tag_name.outputs.branch_or_tag }}")
-          pipelineExecutionId=$(aws codepipeline start-pipeline-execution --name rofim-$ENVIRONMENT-$APP --source-revisions actionName=Source,revisionType=COMMIT_ID,revisionValue=$commit_id |jq .pipelineExecutionId)
+          pipelineExecutionId=$(aws codepipeline start-pipeline-execution --name rofim-${{ inputs.environment }}-${{ inputs.app }} --source-revisions actionName=Source,revisionType=COMMIT_ID,revisionValue=$commit_id | jq .pipelineExecutionId)
           echo "pipelineExecutionId=$pipelineExecutionId" >> $GITHUB_OUTPUT
 
       - name: Check AWS pipeline
         run: |
-          echo ${{ steps.start-pipeline.outputs.pipelineExecutionId }}
+          echo ${{ steps.deploy.outputs.pipelineExecutionId }}
           i=0
           max=80
           while true; do
@@ -84,7 +84,7 @@ jobs:
               echo "Waiting for too long, ... Exiting"
               exit 1
             fi
-            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-$ENVIRONMENT-$APP --pipeline-execution-id ${{ steps.start-pipeline.outputs.pipelineExecutionId }} |jq .pipelineExecution.status -r)
+            status=$(aws codepipeline get-pipeline-execution --pipeline-name rofim-${{ inputs.environment }}-${{ inputs.app }} --pipeline-execution-id ${{ steps.deploy.outputs.pipelineExecutionId }} | jq .pipelineExecution.status -r)
             echo "[$i/$max] Current status is $status"
             if [[ "$status" == "Succeeded" ]]; then
               break


### PR DESCRIPTION
# Description

AWS permet désormais d'exécuter des GH Actions directement via Code build et c'est beaucoup moins cher que nos runners AWS et Github. J’ai remplacé les `runs-on` de toutes nos actions pour utiliser le runner CodeBuild `codebuild-runner-tiny-${{ github.run_id }}-${{ github.run_attempt }}`, mis en place par @keenobi et le runner codebuild-runner-privileged-boosted-${{ github.run_id }}-${{ github.run_attempt }} pour tous les pipelines qui requièrent du Docker.

## JIRA link

[SCRUM-2882](https://jira-rofim.atlassian.net/browse/SCRUM-2882)

## Type of change

-   [x] Chore: catch-all type for any other commits. For instance, if you're implementing a single feature and it makes
    sense to divide the work into multiple commits, you should mark one commit as feat and the rest as chore.

[SCRUM-2882]: https://jira-rofim.atlassian.net/browse/SCRUM-2882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ