### PR TITLE
[fix]: scrum-1841 - fix init socket en premier quand la session est vide

### DIFF
--- a/frontend/src/rofim/context/RofimContext.tsx
+++ b/frontend/src/rofim/context/RofimContext.tsx
@@ -7,7 +7,7 @@ import useWebSocket from '../hooks/useWebSocket';
 
 const RofimInit = ({ children }: PropsWithChildren) => {
   const [isSocketConnectionReady] = useAtom(socketConnectionStatusAtom);
-  const { initSocket, setIsSocketInit } = useWebSocket();
+  const { initSocket } = useWebSocket();
   const [isInit, setIsInit] = useState(false);
   const navigate = useNavigate();
 
@@ -21,7 +21,7 @@ const RofimInit = ({ children }: PropsWithChildren) => {
     }
 
     setIsInit(true);
-  }, [navigate, initSocket, setIsSocketInit]);
+  }, [navigate, initSocket]);
 
   // To avoid blinking page when no token set
   // and accessing waiting-room page, which start camera

--- a/frontend/src/rofim/hooks/useWebSocket.ts
+++ b/frontend/src/rofim/hooks/useWebSocket.ts
@@ -12,11 +12,6 @@ import {
 
 const useWebSocket = () => {
   let socket: Socket | null = null;
-  const rofimSession = getRofimSession();
-  const shouldInitSocket =
-    rofimSession?.patientId &&
-    rofimSession.waitingRoom &&
-    rofimSession?.type === 'teleconsultation';
 
   const [isSocketInit, setIsSocketInit] = useState(false);
   const [, setSocketConnectionReady] = useAtom(socketConnectionStatusAtom);
@@ -45,6 +40,14 @@ const useWebSocket = () => {
   };
 
   const initSocket = () => {
+    // Init socket only for TC patient with waitingRoom active
+    const rofimSession = getRofimSession();
+
+    const shouldInitSocket =
+      rofimSession?.patientId &&
+      rofimSession.waitingRoom &&
+      rofimSession?.type === 'teleconsultation';
+
     // bypass socket connection
     if (!shouldInitSocket) {
       setSocketConnectionReady(true);
@@ -70,9 +73,7 @@ const useWebSocket = () => {
   };
 
   return {
-    shouldInitSocket,
     initSocket,
-    setIsSocketInit,
   };
 };
 


### PR DESCRIPTION
# Description

attendre que la session soit init pour se connecter au socket quand nécessaire pour la waiting room et avant d'update le status de la TC 

## JIRA link

https://jira-rofim.atlassian.net/browse/SCRUM-1841

## Type of change

- [x] Fix: commit that fixes a bug.
- [ ] Feat: commit that adds new functionality.
- [ ] Refactor: commit of changes related to modifying the codebase such as removing redundant code, simplifying the
  code, renaming variables.
- [ ] Docs: commit that adds or improves Uno's documentation.
- [ ] Test: commit that adds unit tests.
- [ ] Perf: commit that improves performance, without functional changes.
- [ ] Chore: catch-all type for any other commits. For instance, if you're implementing a single feature and it makes
  sense to divide the work into multiple commits, you should mark one commit as feat and the rest as chore.